### PR TITLE
Optimize dns

### DIFF
--- a/app/dns/nameserver.go
+++ b/app/dns/nameserver.go
@@ -205,11 +205,21 @@ func (c *Client) MatchExpectedIPs(domain string, ips []net.IP) ([]net.IP, error)
 	}
 	newIps := []net.IP{}
 	for _, ip := range ips {
+		result := false
 		for _, matcher := range c.expectIPs {
 			if matcher.Match(ip) {
-				newIps = append(newIps, ip)
+				result = true
+				if !matcher.IsReverseMatch() {
+					break
+				}
+			} else if matcher.IsReverseMatch() {
+				result = false
 				break
 			}
+		}
+
+		if result {
+			newIps = append(newIps, ip)
 		}
 	}
 	if len(newIps) == 0 {

--- a/app/router/condition.go
+++ b/app/router/condition.go
@@ -143,10 +143,21 @@ func (m *MultiGeoIPMatcher) Apply(ctx routing.Context) bool {
 		ips = ctx.GetTargetIPs()
 	}
 	for _, ip := range ips {
+		result := false
 		for _, matcher := range m.matchers {
 			if matcher.Match(ip) {
-				return true
+				result = true
+				if !matcher.IsReverseMatch() {
+					break
+				}
+			} else if matcher.IsReverseMatch() {
+				result = false
+				break
 			}
+		}
+
+		if result {
+			return true
 		}
 	}
 	return false

--- a/app/router/condition_geoip.go
+++ b/app/router/condition_geoip.go
@@ -85,6 +85,10 @@ func (m *GeoIPMatcher) SetReverseMatch(isReverseMatch bool) {
 	m.reverseMatch = isReverseMatch
 }
 
+func (m *GeoIPMatcher) IsReverseMatch() bool {
+	return m.reverseMatch
+}
+
 func (m *GeoIPMatcher) match4(ip uint32) bool {
 	if len(m.ip4) == 0 {
 		return false


### PR DESCRIPTION
添加全IP反向匹配模式
出现在**正向匹配**前时，**反向匹配**作为**正向匹配**的**过滤器**使用
`["!42.4.0.0/14", "geoip:cn"]`即从`"geoip:cn"`中排除`"42.4.0.0/14"`
当最后一个匹配为**反向匹配**时，**反向匹配**的结果即为最终结果
`["geoip:!us","geoip:!cn"]`或`["!geoip:us","!geoip:cn"]`即为从非cn ip中排除us ip